### PR TITLE
ToDoリストのAPIを作成

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,1 +1,2 @@
 venv
+__pycache__/

--- a/server/main.py
+++ b/server/main.py
@@ -36,7 +36,7 @@ def delete_todo(todo_id: int):
     raise HTTPException(status_code=404, detail="sono id ha naiyo!")
 
 class TodoUpdate(BaseModel):
-    title: str = None
+    title: Optional[str] = None
     is_done: bool = None
 
 #データの編集

--- a/server/main.py
+++ b/server/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
-from typing import List
+from typing import List, Optional
 
 app = FastAPI()
 
@@ -35,6 +35,7 @@ def delete_todo(todo_id: int):
             return todos.pop(i)
     raise HTTPException(status_code=404, detail="sono id ha naiyo!")
 
+#
 class TodoUpdate(BaseModel):
     title: Optional[str] = None
     is_done: bool = None
@@ -42,7 +43,7 @@ class TodoUpdate(BaseModel):
 #データの編集
 @app.put("/todos/{todo_id}", response_model=Todo)
 def update_todo(todo_id: int, todo_update: TodoUpdate):
-    #リクエストと同じIDを探して、todoupdateが空で無ければ編集する
+    #リクエストと同じIDを探して、todoupdateが空でなければ編集する
     for todo in todos:
         if todo.id == todo_id:
             if todo_update.title is not None:

--- a/server/main.py
+++ b/server/main.py
@@ -1,0 +1,53 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from typing import List
+
+app = FastAPI()
+
+class Todo(BaseModel):
+    id: int
+    title: str
+    is_done: bool
+
+todos: List[Todo] = []
+
+#データの受け取り
+@app.get("/todos", response_model=List[Todo])
+def get_todos():
+    return todos
+
+#データの追加
+@app.post("/todos", response_model=Todo)
+def create_todo(todo: Todo):
+    #同じIDがあったら追加できないように確認
+    for i in todos:
+        if i.id == todo.id:
+            raise HTTPException(status_code=400, detail="baka mou id aru")
+    todos.append(todo)
+    return todo
+
+#データの削除
+@app.delete("/todos/{todo_id}", response_model=Todo)
+def delete_todo(todo_id: int):
+    #今あるToDoリストに削除したいIDと同じIDがあれば削除
+    for i, todo in enumerate(todos):
+        if todo.id == todo_id:
+            return todos.pop(i)
+    raise HTTPException(status_code=404, detail="sono id ha naiyo!")
+
+class TodoUpdate(BaseModel):
+    title: str = None
+    is_done: bool = None
+
+#データの編集
+@app.put("/todos/{todo_id}", response_model=Todo)
+def update_todo(todo_id: int, todo_update: TodoUpdate):
+    #リクエストと同じIDを探して、todoupdateが空で無ければ編集する
+    for todo in todos:
+        if todo.id == todo_id:
+            if todo_update.title is not None:
+                todo.title = todo_update.title
+            if todo_update.is_done is not None:
+                todo.is_done = todo_update.is_done
+            return todo
+    raise HTTPException(status_code=404, detail="sono id ha naiyo!")

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,2 +1,4 @@
 fastapi==0.111.0  
 uvicorn[standard]==0.30.1 
+SQLAlchemy==2.0.41
+aiosqlite==0.21.0


### PR DESCRIPTION
## 概要

このプルリクエストでは、既存のToDoアイテムを更新するためのAPIエンドポイントを追加します。

## 変更内容

### `PUT /todos/{todo_id}` エンドポイントの実装

- 指定されたIDのToDoアイテムの`title`（タイトル）と`is_done`（完了フラグ）を更新できるようにしました。
- リクエストボディの検証のため、`TodoUpdate`モデルを追加しました。
- 該当するIDのToDoアイテムが存在しない場合は、`404 Not Found`エラーを返します。

### ファイル変更

- `ToDo/server/main.py`: 上記の更新ロジックを追加しました。

## 確認方法

1. APIサーバーを起動します。
2. `POST /todos` を使って、テスト用のToDoアイテムをいくつか作成します。
3. 作成したToDoアイテムのIDを指定し、`PUT /todos/{todo_id}`エンドポイントに対して、更新したい内容（例: `{"title": "更新後のタイトル", "is_done": true}`）をリクエストボディとして送信します。
4. `GET /todos` または `GET /todos/{todo_id}` を実行し、アイテムが正しく更新されていることを確認します。