### PR TITLE
corsの許可

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -1,6 +1,11 @@
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 from typing import List, Optional
+from sqlalchemy import create_engine, Column, Integer, String, Boolean
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+
 
 app = FastAPI()
 

--- a/server/main.py
+++ b/server/main.py
@@ -4,12 +4,13 @@ from typing import List, Optional
 from sqlalchemy import create_engine, Column, Integer, String, Boolean
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
+from fastapi.middleware.cors import CORSMiddleware
 
 
 
 DB_url = "sqlite:///./todos.db"
 
-engine = create_engine(DB_url, connect_args{"check_same_thread": False})
+engine = create_engine(DB_url, connect_args={"check_same_thread": False})
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
@@ -38,6 +39,16 @@ class TodoUpdate(BaseModel):
 
 
 app = FastAPI()
+
+
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:3000"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 

--- a/server/main.py
+++ b/server/main.py
@@ -7,53 +7,98 @@ from sqlalchemy.orm import sessionmaker
 
 
 
-app = FastAPI()
+DB_url = "sqlite:///./todos.db"
+
+engine = create_engine(DB_url, connect_args{"check_same_thread": False})
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+class TodoDB(Base):
+    __tablename__="todos"
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String, index=True)
+    is_done = Column(Boolean, default=False)
+
+Base.metadata.create_all(bind=engine)
 
 class Todo(BaseModel):
     id: int
     title: str
-    is_done: bool
+    is_done: bool = False
 
-todos: List[Todo] = []
+    class Config:
+        orm_mode = True
+
+class TodoUpdate(BaseModel):
+    title: Optional[str] = None
+    is_done: bool = None
+
+
+
+app = FastAPI()
+
+
 
 #データの受け取り
 @app.get("/todos", response_model=List[Todo])
 def get_todos():
+    db = SessionLocal()
+    todos = db.query(TodoDB).all()
+    db.close()
     return todos
+
 
 #データの追加
 @app.post("/todos", response_model=Todo)
 def create_todo(todo: Todo):
+    db = SessionLocal()
     #同じIDがあったら追加できないように確認
-    for i in todos:
-        if i.id == todo.id:
-            raise HTTPException(status_code=400, detail="baka mou id aru")
-    todos.append(todo)
-    return todo
+    existing_todo = db.query(TodoDB).filter(TodoDB.id == todo.id).first()
+    if existing_todo != None:
+        db.close()
+        raise HTTPException(status_code=400, detail="sono id sudeni aru!")
+
+    db_todo = TodoDB(id=todo.id, title=todo.title, is_done=todo.is_done)
+    db.add(db_todo)
+    db.commit()
+    db.refresh(db_todo)
+    db.close()
+    return db_todo
+
 
 #データの削除
 @app.delete("/todos/{todo_id}", response_model=Todo)
 def delete_todo(todo_id: int):
     #今あるToDoリストに削除したいIDと同じIDがあれば削除
-    for i, todo in enumerate(todos):
-        if todo.id == todo_id:
-            return todos.pop(i)
-    raise HTTPException(status_code=404, detail="sono id ha naiyo!")
+    todo = db.query(TodoDB).filter(TodoDB.id == todo.id).first()
+    if todo == None:
+        db.close()
+        raise HTTPException(status_code=404, detail="sono id ha naiyo!")
 
-#
-class TodoUpdate(BaseModel):
-    title: Optional[str] = None
-    is_done: bool = None
+    db.delete(todo)
+    db.commit()
+    db.close()
+    return todo
+
 
 #データの編集
 @app.put("/todos/{todo_id}", response_model=Todo)
 def update_todo(todo_id: int, todo_update: TodoUpdate):
     #リクエストと同じIDを探して、todoupdateが空でなければ編集する
-    for todo in todos:
-        if todo.id == todo_id:
-            if todo_update.title is not None:
-                todo.title = todo_update.title
-            if todo_update.is_done is not None:
-                todo.is_done = todo_update.is_done
-            return todo
-    raise HTTPException(status_code=404, detail="sono id ha naiyo!")
+    db = SessionLocal()
+    todo = db.query(TodoDB).filter(TodoDB.id == todo_id).first()
+    if todo == None:
+        db.close()
+        raise HTTPException(status_code=404, detail="sono id ha naiyo!")
+
+    if todo_update.title != None:
+        todo.title = todo_update.title
+    if todo_update.is_done != None:
+        todo.is_done = todo_update.is_done
+
+    db.commit()
+    db.refresh()
+    db.close()
+    return todo

--- a/server/main.py
+++ b/server/main.py
@@ -44,7 +44,7 @@ app = FastAPI()
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000"],
+    allow_origins=["http://localhost:5173"],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## 概要

FastAPIサーバーにCORSミドルウェアを追加し、フロントエンド（例: React, Next.js）からのAPIアクセスを許可するようにしました。

## 変更内容

- `main.py` にて `CORSMiddleware` を追加
- `http://localhost:3000` からのリクエストを許可
- すべてのメソッド・ヘッダー・認証情報を許可

```python
app.add_middleware(
    CORSMiddleware,
    allow_origins=["http://localhost:3000"],  # フロントエンドのURL
    allow_credentials=True,
    allow_methods=["*"],
    allow_headers=["*"],
)
```

## 目的

- フロントエンドとバックエンドをローカル環境で連携させるため
- CORSエラーを防ぐため

## 動作確認方法

1. サーバーを起動する
2. フロントエンド（`http://localhost:3000`）からAPIリクエストを送信
3. CORSエラーが発生しないことを確認

## 補足

- 本番環境では `allow_origins` の値を適切に変更してください