### PR TITLE
DB(SQLite)の実装と、関数を使って無駄なコードを整えました。

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -1,21 +1,20 @@
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends
 from pydantic import BaseModel
-from typing import List, Optional
+from typing import List, Optional, Generator
 from sqlalchemy import create_engine, Column, Integer, String, Boolean
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import sessionmaker, Session
 from fastapi.middleware.cors import CORSMiddleware
+from contextlib import contextmanager
 
 
-
+#データベース設定
 DB_url = "sqlite:///./todos.db"
-
 engine = create_engine(DB_url, connect_args={"check_same_thread": False})
-
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-
 Base = declarative_base()
 
+#データベースモデル
 class TodoDB(Base):
     __tablename__="todos"
     id = Column(Integer, primary_key=True, index=True, autoincrement=True)
@@ -24,6 +23,7 @@ class TodoDB(Base):
 
 Base.metadata.create_all(bind=engine)
 
+#Pydanticモデル
 class Todo(BaseModel):
     id: int
     title: str
@@ -32,19 +32,59 @@ class Todo(BaseModel):
     class Config:
         orm_mode = True
 
-class TodoCreate(BaseModel):
+class Create_Todo(BaseModel):
     title: str
 
-class TodoUpdate(BaseModel):
+class Update_Todo(BaseModel):
     title: Optional[str] = None
-    is_done: bool = None
+    is_done: Optional[bool] = None
+
+@contextmanager
+def get_db() -> Generator[Session, None, None]:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
 
 
+#データベース操作をカプセル化
+class TodoRepository:
+    def __init__(self, db: Session):
+        self.db = db
 
+    def get_all(self) -> List[TodoDB]:
+        return self.db.query(TodoDB).all()
+
+    def get_by_id(self, todo_id: int) -> Optional[TodoDB]:
+        return self.db.query(TodoDB).filter(TodoDB.id == todo_id).first()
+
+    def create(self, todo: Create_Todo) -> TodoDB:
+        db_todo = TodoDB(title=todo.title, is_done=False)
+        self.db.add(db_todo)
+        self.db.commit()
+        self.db.refresh(db_todo)
+        return db_todo
+
+    def delete(self, todo: TodoDB) -> TodoDB:
+        self.db.delete(todo)
+        self.db.commit()
+        return todo
+
+    def update(self, todo: TodoDB, todo_update: Update_Todo) ->TodoDB:
+
+        if todo_update.title != None:
+            todo.title = todo_update.title
+        if todo_update.is_done != None:
+            todo.is_done = todo_update.is_done
+        self.db.commit()
+        self.db.refresh(todo)
+        return todo
+
+#fastAPIインスタンス化
 app = FastAPI()
 
-
-
+#CORSの許可
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["http://localhost:5173"],
@@ -53,61 +93,37 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-
-
 #データの受け取り
 @app.get("/todos", response_model=List[Todo])
 def get_todos():
-    db = SessionLocal()
-    todos = db.query(TodoDB).all()
-    db.close()
-    return todos
-
+    with get_db() as db:
+        repo = TodoRepository(db)
+        return repo.get_all()
 
 #データの追加
 @app.post("/todos", response_model=Todo)
-def create_todo(todo: TodoCreate):
-    db = SessionLocal()
-    db_todo = TodoDB(title=todo.title, is_done=False)
-    db.add(db_todo)
-    db.commit()
-    db.refresh(db_todo)
-    db.close()
-    return db_todo
-
+def create_todo(todo: Create_Todo):
+    with get_db() as db:
+        repo = TodoRepository(db)
+        return repo.create(todo)
 
 #データの削除
 @app.delete("/todos/{todo_id}", response_model=Todo)
 def delete_todo(todo_id: int):
-    db = SessionLocal()
-    #今あるToDoリストに削除したいIDと同じIDがあれば削除
-    todo = db.query(TodoDB).filter(TodoDB.id == todo_id).first()
-    if todo == None:
-        db.close()
-        raise HTTPException(status_code=404, detail="sono id ha naiyo!")
-
-    db.delete(todo)
-    db.commit()
-    db.close()
-    return todo
-
+    with get_db() as db:
+        repo = TodoRepository(db)
+        todo = repo.get_by_id(todo_id)
+        if todo == None:
+            raise HTTPException(status_code=404, detail="sono id ha naiyo")
+        return repo.delete(todo)
 
 #データの編集
 @app.put("/todos/{todo_id}", response_model=Todo)
-def update_todo(todo_id: int, todo_update: TodoUpdate):
-    #リクエストと同じIDを探して、todoupdateが空でなければ編集する
-    db = SessionLocal()
-    todo = db.query(TodoDB).filter(TodoDB.id == todo_id).first()
-    if todo == None:
-        db.close()
-        raise HTTPException(status_code=404, detail="sono id ha naiyo!")
-
-    if todo_update.title != None:
-        todo.title = todo_update.title
-    if todo_update.is_done != None:
-        todo.is_done = todo_update.is_done
-
-    db.commit()
-    db.refresh(todo)
-    db.close()
-    return todo
+def update_todo(todo_id: int, todo_update: Update_Todo):
+    #リクエストと同じIDを探して、Update_Todoが空でなければ編集する
+    with get_db() as db:
+        repo = TodoRepository(db)
+        todo = repo.get_by_id(todo_id)
+        if todo == None:
+            raise HTTPException(status_code=404, detail="sono id ha naiyo")
+        return repo.update(todo, todo_update)


### PR DESCRIPTION
## 概要
- Todoの保存方法をメモリからデータベースに変更しました。
- データベースセッション（SessionLocal()とdb.close()）の処理を関数化し、重複コードを削減しました。

## 変更内容

### 1. リファクタリング
- これまで各エンドポイントで毎回SessionLocal()とdb.close()を書いていた部分をwith文で関数化しました。
- 例外発生時も確実にセッションがクローズされ、コードの重複

### 2. DB操作のクラス化
- データベースのCRUD操作をTodoRepositoryクラスにまとめ、エンドポイントから直接DB操作しない構成に変更しました。

---

## 影響範囲
- メモリからDBに変更したことにより、サーバーやWebページをリロールしてもデータが消えないようになりました。
- コードの可読性・保守性が向上しました。

---

## 動作確認
- /docsから各エンドポイントの動作確認済み

---

ご確認よろしくお願いします。 